### PR TITLE
Interrupt execution on pause

### DIFF
--- a/src/GDBBackend.ts
+++ b/src/GDBBackend.ts
@@ -57,15 +57,6 @@ export class GDBBackend extends events.EventEmitter {
         return this.parser.parse(pty.master);
     }
 
-    public pause() {
-        if (this.proc) {
-            this.proc.kill('SIGINT');
-            return true;
-        } else {
-            return false;
-        }
-    }
-
     public async supportsNewUi(gdbPath?: string): Promise<boolean> {
         const gdb = gdbPath || 'gdb';
         return new Promise<boolean>((resolve, reject) => {

--- a/src/GDBDebugSession.ts
+++ b/src/GDBDebugSession.ts
@@ -221,7 +221,7 @@ export class GDBDebugSession extends LoggingDebugSession {
             const waitPromise = new Promise<void>((resolve) => {
                 this.waitPaused = resolve;
             });
-            this.gdb.pause();
+            await mi.sendExecInterrupt(this.gdb);
             await waitPromise;
         }
 
@@ -402,10 +402,12 @@ export class GDBDebugSession extends LoggingDebugSession {
 
     protected async pauseRequest(response: DebugProtocol.PauseResponse,
         args: DebugProtocol.PauseArguments): Promise<void> {
-        if (!this.gdb.pause()) {
-            response.success = false;
+        try {
+            await mi.sendExecInterrupt(this.gdb, args.threadId);
+            this.sendResponse(response);
+        } catch (err) {
+            this.sendErrorResponse(response, 1, err.message);
         }
-        this.sendResponse(response);
     }
 
     protected scopesRequest(response: DebugProtocol.ScopesResponse,

--- a/src/mi/exec.ts
+++ b/src/mi/exec.ts
@@ -24,6 +24,14 @@ export function sendExecContinue(gdb: GDBBackend) {
     return gdb.sendCommand('-exec-continue');
 }
 
+export function sendExecInterrupt(gdb: GDBBackend, threadId?: number) {
+    let command = '-exec-interrupt';
+    if (threadId) {
+        command += ` --thread ${threadId}`;
+    }
+    return gdb.sendCommand(command);
+}
+
 export function sendExecNext(gdb: GDBBackend) {
     return gdb.sendCommand('-exec-next');
 }


### PR DESCRIPTION
This change could prove controversial.

When pausing execution of the adapter, it's set up to kill the process entirely (it's bnot clear why).

This PR changes that to correctly(?) send an interrupt request instead.